### PR TITLE
fix(forceignore): replace non-matching brace globs with gitignore-style patterns

### DIFF
--- a/.forceignore
+++ b/.forceignore
@@ -4,20 +4,17 @@
 
 package.xml
 
-{**,*}/*.md
+**/*.md
 
-{**,*}/manifest/*.xml
+**/manifest/*.xml
 
 # LWC configuration files
-{**,*}/jsconfig.json
-{**,*}/.eslintrc.json
+**/jsconfig.json
+**/.eslintrc.json
 
 # LWC Jest
-{**,*}/__tests__/**
-
-**/jsconfig.json
-
-**/.eslintrc.json
+**/__tests__/**
+**/*.test.js
 
 # Added by Illuminated Cloud
 /.illuminatedCloud/


### PR DESCRIPTION
## Problem

`.forceignore` is matched with **gitignore semantics** (the `ignore` npm lib used by `@salesforce/source-deploy-retrieve`), which does **not** support `{a,b}` brace expansion. The `{**,*}/...` patterns in this template therefore matched **nothing** — `{**,*}` is treated as a literal directory name.

Every project scaffolded from this template inherited the bug. Most visibly, LWC Jest test files under `__tests__/` were **not** excluded from `sf project deploy`, so they got compiled and failed with:

```
LWC1702: Invalid LWC imported identifier "createElement"
```

(test files import `createElement` from `'lwc'`, which is invalid in a component module).

## Fix

Replace the dead brace patterns with canonical `**/...` globs:

| Before (matches nothing) | After |
|---|---|
| `{**,*}/*.md` | `**/*.md` |
| `{**,*}/manifest/*.xml` | `**/manifest/*.xml` |
| `{**,*}/jsconfig.json` | `**/jsconfig.json` |
| `{**,*}/.eslintrc.json` | `**/.eslintrc.json` |
| `{**,*}/__tests__/**` | `**/__tests__/**` |

Also: add `**/*.test.js` (covers test files outside `__tests__/`), drop the now-redundant duplicate `**/jsconfig.json` / `**/.eslintrc.json` lines, and add a trailing newline.

## Verification

Checked against the sf CLI's own bundled `ignore` matcher (org-free):

- `{**,*}/__tests__/**` → `ignores = false` → file deploys → **LWC1702**
- `**/__tests__/**` → `ignores = true` → **excluded, no LWC1702**
- Full file: `cgField.test.js` excluded; `cgField.js` still deploys (no over-match).

🤖 Generated with [Claude Code](https://claude.com/claude-code)